### PR TITLE
Extra argument added to handler function

### DIFF
--- a/src/jsonrpc2.erl
+++ b/src/jsonrpc2.erl
@@ -16,7 +16,10 @@
 
 -type rpc_handler_fun() :: fun((binary(), jsx:json_term()) -> {ok, jsx:json_term()} | 
                                                               {error, rpc_error_reason()} |
-                                                              {error, {rpc_error_reason(), jsx:json_term()}}).
+                                                              {error, {rpc_error_reason(), jsx:json_term()}}) |
+                           fun((binary(), jsx:json_term(), jsx:json_term()) -> {ok, jsx:json_term()} | 
+                                                                               {error, rpc_error_reason()} |
+                                                                               {error, {rpc_error_reason(), jsx:json_term()}}).
 -type rpc_id() :: null | binary() | number().
 
 -export_type([rpc_error_reason/0]).
@@ -26,7 +29,7 @@
 %%====================================================================
 -spec handle(Data :: jsx:json_text(),
              Handler :: rpc_handler_fun()) -> {reply, jsx:json_text()} | noreply.
-handle(Data, Handler) when is_binary(Data) andalso is_function(Handler, 2) orelse is_function(Handler, 3) ->
+handle(Data, Handler) when is_binary(Data) andalso (is_function(Handler, 2) orelse is_function(Handler, 3)) ->
     Response = 
         try 
             begin

--- a/test/jsonrpc2_SUITE.erl
+++ b/test/jsonrpc2_SUITE.erl
@@ -22,26 +22,21 @@ all() -> [
     invalid_json,
     invalid_method,
     invalid_params,
-    server_error,
-    batch_request_with_opts
+    server_error
 ].
 
 simple_request(_Config) ->
-    lists:map(fun(Fun) -> 
-        Request = jsonrpc2_test_utils:build_request(<<"sum">>, [1,2,3], 1),
-        Response = jsonrpc2_test_utils:Fun(Request), 
-        _ = jsonrpc2_test_utils:validate_response(Response, 1),
-        ?assertEqual(6, maps:get(<<"result">>, Response)),
-        ok
-    end, [do_json_rpc, do_json_rpc_with_opts]).
+    Request = jsonrpc2_test_utils:build_request(<<"sum">>, [1,2,3], 1),
+    Response = jsonrpc2_test_utils:do_json_rpc(Request), 
+    _ = jsonrpc2_test_utils:validate_response(Response, 1),
+    ?assertEqual(6, maps:get(<<"result">>, Response)),
+    ok.
 
 simple_event(_Config) ->
-    lists:map(fun(Fun) -> 
-        Request = jsonrpc2_test_utils:build_request(<<"event">>, [], undefined),
-        Response = jsonrpc2_test_utils:Fun(Request), 
-        ?assertEqual(undefined, Response),
-        ok
-    end, [do_json_rpc, do_json_rpc_with_opts]).
+    Request = jsonrpc2_test_utils:build_request(<<"event">>, [], undefined),
+    Response = jsonrpc2_test_utils:do_json_rpc(Request), 
+    ?assertEqual(undefined, Response),
+    ok.
 
 batch_request(_Config) ->
     Ids = lists:seq(1,3),
@@ -52,45 +47,29 @@ batch_request(_Config) ->
     ok.
 
 invalid_json(_Config) ->
-    lists:map(fun(Fun) ->
-        Response = jsonrpc2_test_utils:Fun(<<"abcd efgh">>),
-        _ = jsonrpc2_test_utils:validate_response(Response, null),
-        _ = jsonrpc2_test_utils:validate_error_code(Response, -32700),
-        ok
-    end, [do_json_rpc, do_json_rpc_with_opts]).
-    
+    Response = jsonrpc2_test_utils:do_json_rpc(<<"abcd efgh">>),
+    _ = jsonrpc2_test_utils:validate_response(Response, null),
+    _ = jsonrpc2_test_utils:validate_error_code(Response, -32700),
+    ok.
 
 invalid_method(_Config) ->
-    lists:map(fun(Fun) ->
-        Request = jsonrpc2_test_utils:build_request(<<"undefined_method">>, 123, 1),
-        Response = jsonrpc2_test_utils:Fun(Request),
-        _ = jsonrpc2_test_utils:validate_response(Response, 1),
-        _ = jsonrpc2_test_utils:validate_error_code(Response, -32601),
-        ok
-    end, [do_json_rpc, do_json_rpc_with_opts]).
+    Request = jsonrpc2_test_utils:build_request(<<"undefined_method">>, 123, 1),
+    Response = jsonrpc2_test_utils:do_json_rpc(Request),
+    _ = jsonrpc2_test_utils:validate_response(Response, 1),
+    _ = jsonrpc2_test_utils:validate_error_code(Response, -32601),
+    ok.
 
 invalid_params(_Config) ->
-    lists:map(fun(Fun) ->
-        Request = jsonrpc2_test_utils:build_request(<<"invalid_params">>, 123, 1),
-        Response = jsonrpc2_test_utils:Fun(Request),
-        _ = jsonrpc2_test_utils:validate_response(Response, 1),
-        _ = jsonrpc2_test_utils:validate_error_code(Response, -32602),
-        ok
-    end, [do_json_rpc, do_json_rpc_with_opts]).
+    Request = jsonrpc2_test_utils:build_request(<<"invalid_params">>, 123, 1),
+    Response = jsonrpc2_test_utils:do_json_rpc(Request),
+    _ = jsonrpc2_test_utils:validate_response(Response, 1),
+    _ = jsonrpc2_test_utils:validate_error_code(Response, -32602),
+    ok.
 
 server_error(_Config) ->
-    lists:map(fun(Fun) ->
-        Request = jsonrpc2_test_utils:build_request(<<"sum">>, [a, b, c], 1),
-        Response = jsonrpc2_test_utils:Fun(Request), 
-        _ = jsonrpc2_test_utils:validate_response(Response, 1),
-        _ = jsonrpc2_test_utils:validate_error_code(Response, -32000),
-        ok
-    end, [do_json_rpc, do_json_rpc_with_opts]).
-
-batch_request_with_opts(_Config) ->
-    Ids = lists:duplicate(3,2),
-    Requests = [jsonrpc2_test_utils:build_request(<<"sum">>, [1,2,3], Id) || Id <- Ids],
-    Responses = jsonrpc2_test_utils:do_json_rpc_with_opts(Requests),
-    _ = jsonrpc2_test_utils:validate_response(Responses, Ids),
-    lists:foreach(fun(Response) -> ?assertEqual(12, maps:get(<<"result">>, Response)) end, Responses),
+    Request = jsonrpc2_test_utils:build_request(<<"sum">>, [a, b, c], 1),
+    Response = jsonrpc2_test_utils:do_json_rpc(Request), 
+    _ = jsonrpc2_test_utils:validate_response(Response, 1),
+    _ = jsonrpc2_test_utils:validate_error_code(Response, -32000),
     ok.
+

--- a/test/jsonrpc2_test_utils.erl
+++ b/test/jsonrpc2_test_utils.erl
@@ -8,6 +8,10 @@ handler(<<"sum">>, List) -> {ok, lists:sum(List)};
 handler(<<"event">>, _) -> {ok, #{}};
 handler(<<"invalid_params">>, _) -> {error, invalid_params}.
 
+handler(<<"sum">>, List, Opts) -> {ok, lists:sum([L * maps:get(<<"id">>, Opts) || L <- List])};
+handler(<<"event">>, _, _) -> {ok, #{}};
+handler(<<"invalid_params">>, _, _) -> {error, invalid_params}.
+
 build_request(Method, Params, Id) ->
     Base = #{jsonrpc => <<"2.0">>, 
              method => Method, 
@@ -32,6 +36,12 @@ validate_error_code(Response, ErrorCode) ->
 
 do_json_rpc(Request) ->
     case jsonrpc2:handle(jsx:encode(Request), fun handler/2) of
+        {reply, Data} -> jsx:decode(Data, [return_maps]);
+        noreply -> undefined
+    end.
+
+do_json_rpc_with_opts(Request) ->
+    case jsonrpc2:handle(jsx:encode(Request), fun handler/3) of
         {reply, Data} -> jsx:decode(Data, [return_maps]);
         noreply -> undefined
     end.

--- a/test/jsonrpc2_test_utils.erl
+++ b/test/jsonrpc2_test_utils.erl
@@ -4,11 +4,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-handler(<<"sum">>, List) -> {ok, lists:sum(List)};
-handler(<<"event">>, _) -> {ok, #{}};
-handler(<<"invalid_params">>, _) -> {error, invalid_params}.
-
-handler(<<"sum">>, List, Opts) -> {ok, lists:sum([L * maps:get(<<"id">>, Opts) || L <- List])};
+handler(<<"sum">>, List, _) -> {ok, lists:sum(List)};
 handler(<<"event">>, _, _) -> {ok, #{}};
 handler(<<"invalid_params">>, _, _) -> {error, invalid_params}.
 
@@ -35,12 +31,6 @@ validate_error_code(Response, ErrorCode) ->
     ?assertEqual(ErrorCode, maps:get(<<"code">>, Error)).
 
 do_json_rpc(Request) ->
-    case jsonrpc2:handle(jsx:encode(Request), fun handler/2) of
-        {reply, Data} -> jsx:decode(Data, [return_maps]);
-        noreply -> undefined
-    end.
-
-do_json_rpc_with_opts(Request) ->
     case jsonrpc2:handle(jsx:encode(Request), fun handler/3) of
         {reply, Data} -> jsx:decode(Data, [return_maps]);
         noreply -> undefined

--- a/test/prop_invalid_input.erl
+++ b/test/prop_invalid_input.erl
@@ -7,12 +7,6 @@
 prop_test() ->
     ?FORALL(InvalidBinary, utf8(),
         begin
-            {reply, Reply} = jsonrpc2:handle(InvalidBinary, fun rpc_handler/2),
-            Json = jsx:decode(Reply, [return_maps]),
-            is_expected_reply(Json)
-        end),
-    ?FORALL(InvalidBinary, utf8(),
-        begin
             {reply, Reply} = jsonrpc2:handle(InvalidBinary, fun rpc_handler/3),
             Json = jsx:decode(Reply, [return_maps]),
             is_expected_reply(Json)
@@ -21,9 +15,6 @@ prop_test() ->
 %%%%%%%%%%%%%%%
 %%% Helpers %%%
 %%%%%%%%%%%%%%%
-rpc_handler(_, _) ->
-    throw(unexpected_function_call).
-
 rpc_handler(_, _, _) ->
     throw(unexpected_function_call).
 

--- a/test/prop_invalid_input.erl
+++ b/test/prop_invalid_input.erl
@@ -10,12 +10,21 @@ prop_test() ->
             {reply, Reply} = jsonrpc2:handle(InvalidBinary, fun rpc_handler/2),
             Json = jsx:decode(Reply, [return_maps]),
             is_expected_reply(Json)
+        end),
+    ?FORALL(InvalidBinary, utf8(),
+        begin
+            {reply, Reply} = jsonrpc2:handle(InvalidBinary, fun rpc_handler/3),
+            Json = jsx:decode(Reply, [return_maps]),
+            is_expected_reply(Json)
         end).
 
 %%%%%%%%%%%%%%%
 %%% Helpers %%%
 %%%%%%%%%%%%%%%
 rpc_handler(_, _) ->
+    throw(unexpected_function_call).
+
+rpc_handler(_, _, _) ->
     throw(unexpected_function_call).
 
 is_expected_reply(#{<<"jsonrpc">> := <<"2.0">>,

--- a/test/prop_unexpected_method.erl
+++ b/test/prop_unexpected_method.erl
@@ -7,13 +7,6 @@
 prop_test() ->
     ?FORALL(RequestJson, request_json(),
         begin
-            {reply, Reply} = jsonrpc2:handle(jsx:encode(RequestJson), fun rpc_handler/2),
-            ReplyJson = jsx:decode(Reply, [return_maps, {labels, atom}]),
-            is_expected_reply(ReplyJson) andalso
-            is_expected_id(RequestJson, ReplyJson)
-        end),
-    ?FORALL(RequestJson, request_json(),
-        begin
             {reply, Reply} = jsonrpc2:handle(jsx:encode(RequestJson), fun rpc_handler/3),
             ReplyJson = jsx:decode(Reply, [return_maps, {labels, atom}]),
             is_expected_reply(ReplyJson) andalso
@@ -32,9 +25,6 @@ request_json() ->
             id => Id,
             method => Method,
             params => []}).
-
-rpc_handler(<<>>, _) ->
-    throw(unexpected_function_call).
 
 rpc_handler(<<>>, _, _) ->
     throw(unexpected_function_call).

--- a/test/prop_unexpected_method.erl
+++ b/test/prop_unexpected_method.erl
@@ -11,6 +11,13 @@ prop_test() ->
             ReplyJson = jsx:decode(Reply, [return_maps, {labels, atom}]),
             is_expected_reply(ReplyJson) andalso
             is_expected_id(RequestJson, ReplyJson)
+        end),
+    ?FORALL(RequestJson, request_json(),
+        begin
+            {reply, Reply} = jsonrpc2:handle(jsx:encode(RequestJson), fun rpc_handler/3),
+            ReplyJson = jsx:decode(Reply, [return_maps, {labels, atom}]),
+            is_expected_reply(ReplyJson) andalso
+            is_expected_id(RequestJson, ReplyJson)
         end).
 
 %%%%%%%%%%%%%%%
@@ -27,6 +34,9 @@ request_json() ->
             params => []}).
 
 rpc_handler(<<>>, _) ->
+    throw(unexpected_function_call).
+
+rpc_handler(<<>>, _, _) ->
     throw(unexpected_function_call).
 
 is_expected_reply(#{jsonrpc := <<"2.0">>,


### PR DESCRIPTION
Added a third argument to the handler function which is a map (id and method are passed). In order to not interrupt the modules which are already using handler with two arity, have included when guard to handle both two arity and three arity cases. 